### PR TITLE
Show human-friendly error msg to diagnostics

### DIFF
--- a/epos_hardware/src/util/epos.cpp
+++ b/epos_hardware/src/util/epos.cpp
@@ -475,7 +475,9 @@ bool Epos::init() {
     unsigned int error_number;
     if(!VCS_GetDeviceErrorCode(node_handle_->device_handle->ptr, node_handle_->node_id, i, &error_number, &error_code))
       return false;
-    ROS_WARN_STREAM("EPOS Device Error: 0x" << std::hex << error_number);
+	std::string error_str;
+	GetErrorInfo(error_number, &error_str);
+	ROS_WARN_STREAM("EPOS Device Error: 0x" << std::hex << error_number <<", error msg: '" << error_str << "'" );
   }
 
   bool clear_faults;

--- a/epos_hardware/src/util/epos.cpp
+++ b/epos_hardware/src/util/epos.cpp
@@ -550,13 +550,12 @@ void Epos::write() {
     if(isnan(velocity_cmd_))
       return;
     int cmd = (int)velocity_cmd_;
-    if(max_profile_velocity_ >= 0) {
+	if(max_profile_velocity_ >= 0) {
       if(cmd < -max_profile_velocity_)
 	cmd = -max_profile_velocity_;
       if(cmd > max_profile_velocity_)
 	cmd = max_profile_velocity_;
     }
-
     if(cmd == 0 && halt_velocity_) {
       VCS_HaltVelocityMovement(node_handle_->device_handle->ptr, node_handle_->node_id, &error_code);
     }
@@ -567,7 +566,8 @@ void Epos::write() {
   else if(operation_mode_ == PROFILE_POSITION_MODE) {
     if(isnan(position_cmd_))
       return;
-    VCS_MoveToPosition(node_handle_->device_handle->ptr, node_handle_->node_id, (int)position_cmd_, true, true, &error_code);
+	ROS_INFO("Epos::write: PROFILE_POSITION_MODE position_cmd_=%f",position_cmd_);
+	VCS_MoveToPosition(node_handle_->device_handle->ptr, node_handle_->node_id, (int)position_cmd_, true, true, &error_code);
   }
 }
 
@@ -612,6 +612,11 @@ void Epos::buildMotorStatus(diagnostic_updater::DiagnosticStatusWrapper &stat) {
 	if(VCS_GetDeviceErrorCode(node_handle_->device_handle->ptr, node_handle_->node_id, i, &error_number, &error_code)) {
 	  std::stringstream error_msg;
 	  error_msg << "EPOS Device Error: 0x" << std::hex << error_number;
+
+	  std::string error_str;
+	  GetErrorInfo(error_number, &error_str);
+	  error_msg << "Error msg: '" << error_str << "'";
+
 	  stat.mergeSummary(diagnostic_msgs::DiagnosticStatus::ERROR, error_msg.str());
 	}
 	else {


### PR DESCRIPTION
In case of error, show EPOS2-based error-to-error-string message instead of numeric code of error.
